### PR TITLE
Support for exactSearch/splitWordsSearch properties in FilterText.

### DIFF
--- a/src/NetteDatabaseDataSource.php
+++ b/src/NetteDatabaseDataSource.php
@@ -293,16 +293,24 @@ class NetteDatabaseDataSource implements IDataSource
 		$big_or = '(';
 		$big_or_args = [];
 		$condition = $filter->getCondition();
+		$isSeachExact = $filter->isExactSearch();
+		$operator = $isSeachExact ? '=' : 'LIKE';
 
 		foreach ($condition as $column => $value) {
-			$words = explode(' ', $value);
 
 			$like = '(';
 			$args = [];
 
-			foreach ($words as $word) {
-				$like .= "$column LIKE ? OR ";
-				$args[] = "%$word%";
+			if ($filter->hasSplitWordsSearch() === FALSE) {
+				$like .= "$column $operator ? OR ";
+				$args[] = $isSeachExact ? $value :"%$value%";
+			}else{
+				$words = explode(' ', $value);
+
+				foreach ($words as $word) {
+					$like .= "$column $operator ? OR ";
+					$args[] = $isSeachExact ? $word : "%$word%";
+				}
 			}
 
 			$like = substr($like, 0, strlen($like) - 4).')';


### PR DESCRIPTION
Adding support for missed functions ([setExactSearch](https://ublaboo.org/api/datagrid/class-Ublaboo.DataGrid.Filter.FilterText.html#_setExactSearch), [setSplitWordsSearch](https://ublaboo.org/api/datagrid/class-Ublaboo.DataGrid.Filter.FilterText.html#_setSplitWordsSearch)) callable from datagrid. I try also setup test for this functions.